### PR TITLE
:sparkles: Add origin and credentials parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ Alternatively you can install the package locally and add a script to your proje
 | --proxyUrl     | https://www.google.ie |         |
 | --proxyPartial | foo                   |   proxy |
 | --port         | 8010                  |    8010 |
+| --credentials  | (no value needed)     |   false |
+| --origin       | http://localhost:4200 |       * |

--- a/bin/lcp.js
+++ b/bin/lcp.js
@@ -10,7 +10,9 @@ var optionDefinitions = [
     type: String,
     defaultValue: '/proxy'
   },
-  { name: 'proxyUrl', type: String }
+  { name: 'proxyUrl', type: String },
+  { name: 'credentials', type: Boolean, defaultValue: false },
+  { name: 'origin', type: String, defaultValue: '*' }
 ];
 
 try {
@@ -18,7 +20,7 @@ try {
   if (!options.proxyUrl) {
     throw new Error('--proxyUrl is required');
   }
-  lcp.startProxy(options.port, options.proxyUrl, options.proxyPartial);
+  lcp.startProxy(options.port, options.proxyUrl, options.proxyPartial, options.credentials, options.origin);
 } catch (error) {
   console.error(error);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,17 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
     try {
       console.log(chalk.green('Request Proxied -> ' + req.url));
     } catch (e) {}
-    req.pipe(request(cleanProxyUrl + req.url)).pipe(res);
+    req.pipe(
+      request(cleanProxyUrl + req.url)
+      .on('response', response => {
+        // In order to avoid https://github.com/expressjs/cors/issues/134
+        const accessControlAllowOriginHeader = response.headers['access-control-allow-origin']
+        if(accessControlAllowOriginHeader && accessControlAllowOriginHeader !== origin ){
+          console.log(chalk.blue('Override access-control-allow-origin header from proxified URL : ' + chalk.green(accessControlAllowOriginHeader) + '\n'));
+          response.headers['access-control-allow-origin'] = origin;
+        }
+      })
+    ).pipe(res);
   });
 
   proxy.listen(port);

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,9 @@ var cors = require('cors');
 var chalk = require('chalk');
 var proxy = express();
 
-var startProxy = function(port, proxyUrl, proxyPartial) {
-  proxy.use(cors());
-  proxy.options('*', cors());
+var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
+  proxy.use(cors({credentials: credentials, origin: origin}));
+  proxy.options('*', cors({credentials: credentials, origin: origin}));
 
   // remove trailing slash
   var cleanProxyUrl = proxyUrl.replace(/\/$/, '');
@@ -26,7 +26,9 @@ var startProxy = function(port, proxyUrl, proxyPartial) {
   console.log(chalk.bgGreen.black.bold.underline('\n Proxy Active \n'));
   console.log(chalk.blue('Proxy Url: ' + chalk.green(cleanProxyUrl)));
   console.log(chalk.blue('Proxy Partial: ' + chalk.green(cleanProxyPartial)));
-  console.log(chalk.blue('PORT: ' + chalk.green(port) + '\n'));
+  console.log(chalk.blue('PORT: ' + chalk.green(port)));
+  console.log(chalk.blue('Credentials: ' + chalk.green(credentials)));
+  console.log(chalk.blue('Origin: ' + chalk.green(origin) + '\n'));
   console.log(
     chalk.cyan(
       'To start using the proxy simply replace the proxied part of your url with: ' +

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "main": "./lib/index.js",
   "scripts": {
+    "start": "node ./bin/lcp.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin": {
@@ -14,7 +15,13 @@
     "type": "git",
     "url": "git+https://github.com/garmeeh/local-cors-proxy.git"
   },
-  "keywords": ["cors", "proxy", "simple", "node", "express"],
+  "keywords": [
+    "cors",
+    "proxy",
+    "simple",
+    "node",
+    "express"
+  ],
   "bugs": {
     "url": "https://github.com/garmeeh/local-cors-proxy/issues"
   },


### PR DESCRIPTION
Setting "*" in origin parameter doesn't always works.

Especially it doesn't works when credentials are used.
We have the following message:

```
Access to XMLHttpRequest at 'http://localhost:8010/proxy/...' from origin 'http://localhost:4200' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```

So I added the setting "origin" to set a specific origin, here `--origin http://localhost:4200`

But it still doesn't work because:

```
Access to XMLHttpRequest at 'http://localhost:8010/proxy/...' from origin 'http://localhost:4200' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```

So I added the setting `--credentials`.

And it works :tada: 

Thank you for this project :pray: 