### PR TITLE
support fully anonymising requests

### DIFF
--- a/bin/lcp.js
+++ b/bin/lcp.js
@@ -12,7 +12,8 @@ var optionDefinitions = [
   },
   { name: 'proxyUrl', type: String },
   { name: 'credentials', type: Boolean, defaultValue: false },
-  { name: 'origin', type: String, defaultValue: '*' }
+  { name: 'origin', type: String, defaultValue: '*' },
+  { name: 'anonymous', type: Boolean, defaultValue: false },
 ];
 
 try {
@@ -20,7 +21,7 @@ try {
   if (!options.proxyUrl) {
     throw new Error('--proxyUrl is required');
   }
-  lcp.startProxy(options.port, options.proxyUrl, options.proxyPartial, options.credentials, options.origin);
+  lcp.startProxy(options.port, options.proxyUrl, options.proxyPartial, options.credentials, options.origin, options.anonymous);
 } catch (error) {
   console.error(error);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,15 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin, ano
     } catch (e) {}
 
     if (anonymous) {
+      delete req.headers['forwarded'];
+      delete req.headers['via'];
       delete req.headers['x-client-ip'];
+      delete req.headers['x-client-ssl'];
+      delete req.headers['x-client-verify'];
       delete req.headers['x-forwarded-for'];
+      delete req.headers['x-forwarded-host'];
+      delete req.headers['x-forwarded-proto'];
+      delete req.headers['x-real-ip'];
     }
 
     req.pipe(

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,9 +2,10 @@ var express = require('express');
 var request = require('request');
 var cors = require('cors');
 var chalk = require('chalk');
+
 var proxy = express();
 
-var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
+var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin, anonymous) {
   proxy.use(cors({credentials: credentials, origin: origin}));
   proxy.options('*', cors({credentials: credentials, origin: origin}));
 
@@ -17,6 +18,12 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
     try {
       console.log(chalk.green('Request Proxied -> ' + req.url));
     } catch (e) {}
+
+    if (anonymous) {
+      delete req.header['x-client-ip'];
+      delete req.header['x-forwarded-for'];
+    }
+
     req.pipe(
       request(cleanProxyUrl + req.url)
       .on('response', response => {
@@ -38,7 +45,8 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
   console.log(chalk.blue('Proxy Partial: ' + chalk.green(cleanProxyPartial)));
   console.log(chalk.blue('PORT: ' + chalk.green(port)));
   console.log(chalk.blue('Credentials: ' + chalk.green(credentials)));
-  console.log(chalk.blue('Origin: ' + chalk.green(origin) + '\n'));
+  console.log(chalk.blue('Origin: ' + chalk.green(origin)));
+  console.log(chalk.blue('Anonymous: ' + chalk.green(anonymous) + '\n'));
   console.log(
     chalk.cyan(
       'To start using the proxy simply replace the proxied part of your url with: ' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,8 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin, ano
     } catch (e) {}
 
     if (anonymous) {
-      delete req.header['x-client-ip'];
-      delete req.header['x-forwarded-for'];
+      delete req.headers['x-client-ip'];
+      delete req.headers['x-forwarded-for'];
     }
 
     req.pipe(


### PR DESCRIPTION
support fully anonymising requests by removing `x-client-ip` and `x-forwarded-for` from the original request headers when `--anonymous` is passed to lcp