### PR TITLE
Add access-control-expose-headers to response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
       request(cleanProxyUrl + req.url)
       .on('response', response => {
         // Allow client access to all non-standard headers
-        response.headers['access-control-allow-headers'] = "after-cursor,current-page,page-items,total-count,total-pages";
+        response.headers['access-control-expose-headers'] = "*";
         // In order to avoid https://github.com/expressjs/cors/issues/134
         const accessControlAllowOriginHeader = response.headers['access-control-allow-origin']
         if(accessControlAllowOriginHeader && accessControlAllowOriginHeader !== origin ){

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,8 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
     req.pipe(
       request(cleanProxyUrl + req.url)
       .on('response', response => {
+        // Allow client access to all non-standard headers
+        response.headers['access-control-allow-headers'] = "*";
         // In order to avoid https://github.com/expressjs/cors/issues/134
         const accessControlAllowOriginHeader = response.headers['access-control-allow-origin']
         if(accessControlAllowOriginHeader && accessControlAllowOriginHeader !== origin ){

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
       request(cleanProxyUrl + req.url)
       .on('response', response => {
         // Allow client access to all non-standard headers
-        response.headers['access-control-allow-headers'] = "*";
+        response.headers['access-control-allow-headers'] = "after-cursor,current-page,page-items,total-count,total-pages";
         // In order to avoid https://github.com/expressjs/cors/issues/134
         const accessControlAllowOriginHeader = response.headers['access-control-allow-origin']
         if(accessControlAllowOriginHeader && accessControlAllowOriginHeader !== origin ){


### PR DESCRIPTION
This will allow the client to access non-standard headers