### PR TITLE
feat(cookies): follow redirects and proxy cookie header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,30 +4,38 @@ var cors = require('cors');
 var chalk = require('chalk');
 var proxy = express();
 
-var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
-  proxy.use(cors({credentials: credentials, origin: origin}));
-  proxy.options('*', cors({credentials: credentials, origin: origin}));
+var startProxy = function (port, proxyUrl, proxyPartial, credentials, origin) {
+  proxy.use(cors({ credentials: credentials, origin: origin }));
+  proxy.options('*', cors({ credentials: credentials, origin: origin }));
 
   // remove trailing slash
   var cleanProxyUrl = proxyUrl.replace(/\/$/, '');
   // remove all forward slashes
   var cleanProxyPartial = proxyPartial.replace(/\//g, '');
 
-  proxy.use('/' + cleanProxyPartial, function(req, res) {
+  proxy.use('/' + cleanProxyPartial, function (req, res) {
     try {
-      console.log(chalk.green('Request Proxied -> ' + req.url));
-    } catch (e) {}
-    req.pipe(
-      request(cleanProxyUrl + req.url)
-      .on('response', response => {
-        // In order to avoid https://github.com/expressjs/cors/issues/134
-        const accessControlAllowOriginHeader = response.headers['access-control-allow-origin']
-        if(accessControlAllowOriginHeader && accessControlAllowOriginHeader !== origin ){
-          console.log(chalk.blue('Override access-control-allow-origin header from proxified URL : ' + chalk.green(accessControlAllowOriginHeader) + '\n'));
-          response.headers['access-control-allow-origin'] = origin;
-        }
-      })
-    ).pipe(res);
+      console.log(chalk.green('Request Proxied -> ' + req.url + ' ' + req.method));
+    } catch (e) { }
+
+
+    // follow original http method &  follow redirects
+    const proxy_req = request({ followOriginalHttpMethod: true, followAllRedirects: true, url: cleanProxyUrl + req.url });
+    // cookie is essential and should be piped to proxied api
+    proxy_req.headers.cookie = req.headers.cookie;
+
+    proxy_req.on('response', response => {
+      // In order to avoid https://github.com/expressjs/cors/issues/134
+      const accessControlAllowOriginHeader = response.headers['access-control-allow-origin']
+      if (accessControlAllowOriginHeader && accessControlAllowOriginHeader !== origin) {
+        console.log(chalk.blue('Override access-control-allow-origin header from proxified URL : ' + chalk.green(accessControlAllowOriginHeader) + '\n'));
+        response.headers['access-control-allow-origin'] = origin;
+      }
+      // allow credential
+      response.headers['access-control-allow-credentials'] = true;
+    }).pipe(res);
+
+    req.pipe(proxy_req)
   });
 
   proxy.listen(port);
@@ -42,7 +50,7 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
   console.log(
     chalk.cyan(
       'To start using the proxy simply replace the proxied part of your url with: ' +
-        chalk.bold('http://localhost:' + port + '/' + cleanProxyPartial + '\n')
+      chalk.bold('http://localhost:' + port + '/' + cleanProxyPartial + '\n')
     )
   );
 };


### PR DESCRIPTION
- follow redirects
- follow original HTTP method (e.g.: HTTP -> HTTPS: causes POST request proxied as GET requests)
- proxy cookie header field explicitly (was not passed on POST requests here) 
 - set 'access-control-allow-credentials'=true always