### PR TITLE
Option to use https

### DIFF
--- a/bin/lcp.js
+++ b/bin/lcp.js
@@ -12,7 +12,10 @@ var optionDefinitions = [
   },
   { name: 'proxyUrl', type: String },
   { name: 'credentials', type: Boolean, defaultValue: false },
-  { name: 'origin', type: String, defaultValue: '*' }
+  { name: 'origin', type: String, defaultValue: '*' },
+  { name: 'key', alias: 'k', type: String, defaultValue: '' },
+  { name: 'cert', alias: 'c', type: String, defaultValue: '' },
+  { name: 'passphrase', type: String, defaultValue: undefined },
 ];
 
 try {
@@ -20,7 +23,7 @@ try {
   if (!options.proxyUrl) {
     throw new Error('--proxyUrl is required');
   }
-  lcp.startProxy(options.port, options.proxyUrl, options.proxyPartial, options.credentials, options.origin);
+  lcp.startProxy(options.port, options.proxyUrl, options.proxyPartial, options.credentials, options.origin, options.key, options.cert, options.passphrase);
 } catch (error) {
   console.error(error);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,10 @@ var request = require('request');
 var cors = require('cors');
 var chalk = require('chalk');
 var proxy = express();
+var https = require('https')
+var fs = require('fs')
 
-var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
+var startProxy = function (port, proxyUrl, proxyPartial, credentials, origin, key, cert, passphrase) {
   proxy.use(cors({credentials: credentials, origin: origin}));
   proxy.options('*', cors({credentials: credentials, origin: origin}));
 
@@ -12,8 +14,10 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
   var cleanProxyUrl = proxyUrl.replace(/\/$/, '');
   // remove all forward slashes
   var cleanProxyPartial = proxyPartial.replace(/\//g, '');
+  // check if certificate and key are present for secure connection
+  var secure = cert && key
 
-  proxy.use('/' + cleanProxyPartial, function(req, res) {
+  proxy.use('/' + cleanProxyPartial, function (req, res) {
     try {
       console.log(chalk.green('Request Proxied -> ' + req.url));
     } catch (e) {}
@@ -30,7 +34,18 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
     ).pipe(res);
   });
 
-  proxy.listen(port);
+  if (secure) {
+    var keyFile = fs.readFileSync(key);
+    var certFile = fs.readFileSync(cert);
+
+    https.createServer({
+      key: keyFile,
+      cert: certFile,
+      passphrase
+    }, proxy).listen(port);
+  } else {
+    proxy.listen(port)
+  }
 
   // Welcome Message
   console.log(chalk.bgGreen.black.bold.underline('\n Proxy Active \n'));
@@ -42,7 +57,7 @@ var startProxy = function(port, proxyUrl, proxyPartial, credentials, origin) {
   console.log(
     chalk.cyan(
       'To start using the proxy simply replace the proxied part of your url with: ' +
-        chalk.bold('http://localhost:' + port + '/' + cleanProxyPartial + '\n')
+        chalk.bold(`${secure ? 'https' : 'http'}://localhost:${port}/${cleanProxyPartial}\n`)
     )
   );
 };


### PR DESCRIPTION
I've encountered a use case where I needed an HTTPS proxy, so I added an option to pass a certificate, key, and passphrase.

Using with HTTPS:
`lcp --proxyUrl https://www.yourdomain.ie --cert ./path/to/cert.pem --key ./path/to/key.pem`

